### PR TITLE
updated docs/index manager link

### DIFF
--- a/app/views/docs/index.html.erb
+++ b/app/views/docs/index.html.erb
@@ -18,7 +18,7 @@
 
 <article>
   <div><h3><%= link_to "Controller patterns", docs_path("controller_patterns") %></h3> <span>Common controller abstractions</span></div>
-  <div><h3><%= link_to "Controller Manager", docs_path("controller_manager") %></h3> <span>Controller state machine</span></div>
+  <div><h3><%= link_to "Manager", docs_path("manager") %></h3> <span>Controller state machine</span></div>
   <div><h3><%= link_to "Forms & Validation", docs_path("forms") %></h3> <span>Process forms and validate models</span></div>
   <div><h3><%= link_to "Ajax", docs_path("ajax") %></h3> <span>Custom Ajax integration with models</span></div>
   <div><h3><%= link_to "Hem", docs_path("hem") %></h3> <span>Dependency management with Hem</span></div>


### PR DESCRIPTION
The link the controller manager was broken, I also noticed that the controller manager page was called manger.

I've updated the link and title to suit.
