### PR TITLE
Remove Active Record references

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,7 @@ gem 'nestful', :git => 'git://github.com/maccman/nestful.git'
 gem 'omniauth', :git => 'git://github.com/intridea/omniauth.git'
 gem 'rdiscount'
 
-group :development do 
-  gem 'sqlite3'
+group :development do
   gem 'heroku'
   gem 'ruby-debug19', :require => 'ruby-debug'
 end
@@ -26,8 +25,4 @@ end
 group :test do
   # Pretty printed test output
   gem 'turn', :require => false
-end
-
-group :production do
-  gem 'pg'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
       treetop (~> 1.4.8)
     mime-types (1.16)
     multi_json (1.0.3)
-    pg (0.11.0)
     polyglot (0.3.2)
     rack (1.3.2)
     rack-cache (1.0.3)
@@ -147,7 +146,6 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (!= 1.3.0, ~> 1.1)
-    sqlite3 (1.3.4)
     term-ansicolor (1.0.6)
     thin (1.2.11)
       daemons (>= 1.0.9)
@@ -174,11 +172,9 @@ DEPENDENCIES
   jquery-rails
   nestful!
   omniauth!
-  pg
   rails!
   rdiscount
   ruby-debug19
-  sqlite3
   stylus!
   thin
   turn

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,10 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "active_resource/railtie"
+require "rails/test_unit/railtie"
+require "sprockets/railtie"
 
 if defined?(Bundler)
   # If you precompile assets before deploying to production, use this line
@@ -41,5 +45,10 @@ module SpineSite
 
     # Enable the asset pipeline
     config.assets.enabled = true
+
+    config.generators do |generators|
+      generators.orm nil
+    end
+
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -23,7 +23,7 @@ SpineSite::Application.configure do
   config.action_dispatch.best_standards_support = :builtin
 
   # Raise exception on mass assignment protection for ActiveRecord models
-  config.active_record.mass_assignment_sanitizer = :strict
+  # config.active_record.mass_assignment_sanitizer = :strict
 
   # Do not compress assets
   config.assets.compress = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,7 @@ SpineSite::Application.configure do
   # config.active_record.schema_format = :sql
 
   # Raise exception on mass assignment protection for ActiveRecord models
-  config.active_record.mass_assignment_sanitizer = :strict
+  # config.active_record.mass_assignment_sanitizer = :strict
 
   # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
I don't think it's unnecessary to load Active Record or the sqlite and postgres gems.

To ensure this worked in both development and production I deployed this branch to [blazing-frost-4454.herokuapp.com](http://blazing-frost-4454.herokuapp.com).
