### PR TITLE
Excape <%= %> tags with <%%= %> on Contacts Example docs page

### DIFF
--- a/app/views/docs/example_contacts.md
+++ b/app/views/docs/example_contacts.md
@@ -153,8 +153,8 @@ Notice in the `render()` function we're requiring a template under `views/show`,
     </header>
 
     <div class="content">
-      <p><%= @name %></p>
-      <p><%= @email %></p>
+      <p><%%= @name %></p>
+      <p><%%= @email %></p>
     </div>
 
 This is an [eco](<%= docs_path("views") %>) template, and the syntax inside the template tags (`<%%= %>`) is CoffeeScript. We're pulling out the `name` and `email` properties from the contact, displaying them in the page. We've also got that edit link we talked about earlier, ready to be clicked.
@@ -206,12 +206,12 @@ Again, we're requiring a template under `views/form`, rendering it with the curr
       <form>
         <label>
           <span>Name</span>
-          <input type="text" name="name" value="<%= @name %>">
+          <input type="text" name="name" value="<%%= @name %>">
         </label>
 
         <label>
           <span>Email</span>
-          <input type="email" name="email" value="<%= @email %>">
+          <input type="email" name="email" value="<%%= @email %>">
         </label>  
 
         <button>Save</button>


### PR DESCRIPTION
Hey, I was scratching my head trying to understand the examples, and figured out you have <%= %> interpreted as ERB code when it should be escaped in examples. This fixes it on Contacts example page, I'll send more pull requests if find more of these.
