### PR TITLE
Some quoted ECO tag openings get rendered like unquoted ones

### DIFF
--- a/app/views/docs/views.md
+++ b/app/views/docs/views.md
@@ -23,9 +23,9 @@ Here's an example:
       No projects
     <%% end %>
 
-As you can see, the syntax is remarkably straightforward. Just use `<%%` tags for evaluating expressions, and `<%%=` tags for printing them. The full list of template tags is as follows:
+As you can see, the syntax is remarkably straightforward. Just use `<%%` tags for evaluating expressions, and `<%=` tags for printing them. The full list of template tags is as follows:
     
-* `<%% expression %>`  
+* `<% expression %>`  
   Evaluate a CoffeeScript expression without printing its return value.
 
 * `<%%= expression %>`  


### PR DESCRIPTION
For example I see this on http://spinejs.com/docs/views - `Just use <% tags for evaluating expressions, and <%%= tags for printing them.` and `<%% expression %>`.

The changes fixed the representation on the local server I tested them on.
