### PR TITLE
Update information about ability to disable ajax with model's methods options

### DIFF
--- a/app/views/docs/ajax.md
+++ b/app/views/docs/ajax.md
@@ -349,6 +349,11 @@ Ajax requests are sent automatically whenever any model records are created, upd
     Spine.Ajax.disable ->
       record.destroy()
       
+Alternatively if you just want to disable Ajax for a single operation, you can pass the option `{ajax: false}` to the model's methods.
+
+    //= CoffeeScript
+    record.destroy({ajax: false})
+
 If you just want the Ajax methods, without any of the automatic create/update/destroy Ajax requests, extend the model with `Spine.Model.Ajax.Methods` instead of `Spine.Model.Ajax`:
     
     //= CoffeeScript


### PR DESCRIPTION
To be honest I think the "Full API" page should be updated as well, it's not written that most of these methods accept options.
