### PR TITLE
Fix momentum scrolling in iOS

### DIFF
--- a/app/assets/stylesheets/theme.css.styl
+++ b/app/assets/stylesheets/theme.css.styl
@@ -6,6 +6,7 @@ body, html
   margin: 0
   padding: 0
   overflow: auto
+  -webkit-overflow-scrolling: touch
 
 body
   color: #52585D


### PR DESCRIPTION
When `overflow` is set to `auto`, iOS does not enable momentum
scrolling for the overflowed content unless it is explicitly set
with `-webkit-overflow-scrolling: touch`. This was most evident on
the examples page on an iPad. I added that rule to the body, which
maintains its 100% height and auto overflow, and momentum scrolling
works as expected.
